### PR TITLE
Vending machine stock buff

### DIFF
--- a/code/modules/vending/youtool.dm
+++ b/code/modules/vending/youtool.dm
@@ -23,11 +23,11 @@
 		/obj/item/clothing/gloves/color/fyellow = 2,
 	)
 	premium = list(
-		/obj/item/storage/belt/utility = 2,
+		/obj/item/storage/belt/utility = 4,
 		/obj/item/multitool = 2,
 		/obj/item/weldingtool/hugetank = 2,
 		/obj/item/clothing/head/utility/welding = 2,
-		/obj/item/clothing/gloves/color/yellow = 1,
+		/obj/item/clothing/gloves/color/yellow = 2,
 	)
 	refill_canister = /obj/item/vending_refill/youtool
 	default_price = PAYCHECK_CREW


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Toolbelt stock is now 4 (from 2) and insuls stock is 2 (from 1)
Libital and aiuri stock is now 3 (from 2)


Draft bcuz I may buff something else too

## Why It's Good For The Game

These items are very in-demand and with all the great moneymaking methods, there's just too little things to spend it on. Very mild buff as these items do affect the round in a big way.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: toolbelt stock is now 4 and insul stock is now 2 in youtool, medical sprays in nanomed plus is 3 now
/:cl: